### PR TITLE
feat(blog): add clap button for blog posts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1988,6 +1988,14 @@
         "fast-json-stable-stringify": "^2.0.0"
       }
     },
+    "applause-button": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/applause-button/-/applause-button-1.3.0.tgz",
+      "integrity": "sha512-kBwWBwO8g7ixcwdEZzQuCXk7xeZAk2HZMYZOtVDQZGeRNMcU3gtn0e8Q4hUZ+e1c+llQ3PCVLZtkB6oOjl4Okw==",
+      "requires": {
+        "document-register-element": "^1.8.1"
+      }
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -5790,6 +5798,14 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "document-register-element": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/document-register-element/-/document-register-element-1.11.1.tgz",
+      "integrity": "sha512-MvvjYBv6JUrmo+qqnlQXXw6ogW72asARm2QoQRsdKBAC7e4RGf95Cv2hmm+3E5/XuJnbtPXv33PEvro9KCdUAQ==",
+      "requires": {
+        "lightercollective": "^0.1.0"
       }
     },
     "dom-converter": {
@@ -11337,6 +11353,11 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
       }
+    },
+    "lightercollective": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lightercollective/-/lightercollective-0.1.0.tgz",
+      "integrity": "sha512-J9tg5uraYoQKaWbmrzDDexbG6hHnMcWS1qLYgJSWE+mpA3U5OCSeMUhb+K55otgZJ34oFdR0ECvdIb3xuO5JOQ=="
     },
     "lint-staged": {
       "version": "7.2.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "homepage": "https://nickymeuleman.netlify.com/",
   "dependencies": {
+    "applause-button": "^1.3.0",
     "babel-plugin-styled-components": "^1.5.1",
     "gatsby": "^2.0.0-beta.106",
     "gatsby-image": "^2.0.0-beta.8",

--- a/src/components/ApplauseButton/ApplauseButton.js
+++ b/src/components/ApplauseButton/ApplauseButton.js
@@ -15,11 +15,13 @@ export default class ApplauseButton extends Component {
   render() {
     return (
       <div key={this.props.location.href}>
-        <applause-button
-          multiclap
-          color="rgba(21,87,153,1)"
-          style={{ width: '58px', height: '58px', zIndex: '9999', marginBottom: rhythm(1) }}
-        />
+        {typeof window !== 'undefined' && (
+          <applause-button
+            multiclap
+            color="rgba(21,87,153,1)"
+            style={{ width: '58px', height: '58px', zIndex: '9999', marginBottom: rhythm(1) }}
+          />
+        )}
       </div>
     );
   }

--- a/src/components/ApplauseButton/ApplauseButton.js
+++ b/src/components/ApplauseButton/ApplauseButton.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
-import Helmet from 'react-helmet';
+
+import 'applause-button';
+
 import { rhythm } from '../../utils/typography';
 
 export default class ApplauseButton extends Component {
@@ -13,18 +15,8 @@ export default class ApplauseButton extends Component {
   render() {
     return (
       <div key={this.props.location.href}>
-        <Helmet>
-          <link
-            rel="stylesheet"
-            href="https://unpkg.com/applause-button/dist/applause-button.css
-"
-          />
-          <script
-            src="https://unpkg.com/applause-button/dist/applause-button.js
-"
-          />
-        </Helmet>
         <applause-button
+          multiclap
           color="rgba(21,87,153,1)"
           style={{ width: '58px', height: '58px', zIndex: '9999', marginBottom: rhythm(1) }}
         />

--- a/src/components/ApplauseButton/ApplauseButton.js
+++ b/src/components/ApplauseButton/ApplauseButton.js
@@ -1,0 +1,34 @@
+import React, { Component } from 'react';
+import Helmet from 'react-helmet';
+import { rhythm } from '../../utils/typography';
+
+export default class ApplauseButton extends Component {
+  componentDidMount() {
+    console.log('APPLAUSEBUTTON DID MOUNT');
+  }
+  componentDidUpdate() {
+    console.log('APPLAUSEBUTTON DID UPDATE');
+  }
+
+  render() {
+    return (
+      <div key={this.props.location.href}>
+        <Helmet>
+          <link
+            rel="stylesheet"
+            href="https://unpkg.com/applause-button/dist/applause-button.css
+"
+          />
+          <script
+            src="https://unpkg.com/applause-button/dist/applause-button.js
+"
+          />
+        </Helmet>
+        <applause-button
+          color="rgba(21,87,153,1)"
+          style={{ width: '58px', height: '58px', zIndex: '9999', marginBottom: rhythm(1) }}
+        />
+      </div>
+    );
+  }
+}

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { TABLET_WIDTH, LARGE_DISPLAY_WIDTH } from 'typography-breakpoint-constants';
 import Layout from '../components/Layout/Layout';
 import Hero from '../components/Hero/Hero';
+import ApplauseButton from '../components/ApplauseButton/ApplauseButton';
 import { rhythm, scale } from '../utils/typography';
 
 const LinkU = styled(Link)`
@@ -122,11 +123,7 @@ const BlogPostTemplate = ({ data, pageContext, location }) => {
           <div dangerouslySetInnerHTML={{ __html: post.html }} />
         </article>
         <UnderPost>
-          <applause-button
-            key={location}
-            color="rgba(21,87,153,1)"
-            style={{ width: '58px', height: '58px', zIndex: '9999', marginBottom: rhythm(1) }}
-          />
+          <ApplauseButton location={location} />
           <Adjacent>
             <div>
               {prev && (

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -19,7 +19,20 @@ const LinkU = styled(Link)`
 `;
 
 const UnderPost = styled.div`
-  margin: ${rhythm(1)};
+  margin: ${rhythm(2)} ${rhythm(1)};
+
+  @media (min-width: ${TABLET_WIDTH}) {
+    max-width: calc(100vw - 3rem);
+    width: 40rem;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  @media (min-width: ${LARGE_DISPLAY_WIDTH}) {
+    width: 60rem;
+  }
+`;
+
+const Adjacent = styled.div`
   display: flex;
   justify-content: space-between;
   & > * {
@@ -33,16 +46,6 @@ const UnderPost = styled.div`
   }
   [data-next] {
     text-align: right;
-  }
-
-  @media (min-width: ${TABLET_WIDTH}) {
-    max-width: calc(100vw - 3rem);
-    width: 40rem;
-    margin-left: auto;
-    margin-right: auto;
-  }
-  @media (min-width: ${LARGE_DISPLAY_WIDTH}) {
-    width: 60rem;
   }
 `;
 
@@ -99,6 +102,15 @@ const BlogPostTemplate = ({ data, pageContext }) => {
             (post.frontmatter.cover ? post.frontmatter.cover.childImageSharp.sizes.src : '/icons/icon-256x256.png')
           }
         />
+        <link
+          rel="stylesheet"
+          href="https://unpkg.com/applause-button/dist/applause-button.css
+"
+        />
+        <script
+          src="https://unpkg.com/applause-button/dist/applause-button.js
+"
+        />
       </Helmet>
       <Container>
         <Hero
@@ -110,26 +122,32 @@ const BlogPostTemplate = ({ data, pageContext }) => {
           <div dangerouslySetInnerHTML={{ __html: post.html }} />
         </article>
         <UnderPost>
-          <div>
-            {prev && (
-              <LinkU to={`/blog${prev.fields.slug}`}>
-                <h4>Older</h4>
-                <span data-prev style={{ width: '1rem', marginLeft: '-1rem' }}>
-                  ←
-                </span>
-                <span>{prev.frontmatter.title}</span>
-              </LinkU>
-            )}
-          </div>
-          <div data-next>
-            {next && (
-              <LinkU to={`/blog${next.fields.slug}`}>
-                <h4>Newer</h4>
-                <span>{next.frontmatter.title}</span>
-                <span style={{ width: '1rem', marginRight: '-1rem' }}>→</span>
-              </LinkU>
-            )}
-          </div>
+          <applause-button
+            color="rgba(21,87,153,1)"
+            style={{ width: '58px', height: '58px', zIndex: '9999', marginBottom: rhythm(1) }}
+          />
+          <Adjacent>
+            <div>
+              {prev && (
+                <LinkU to={`/blog${prev.fields.slug}`}>
+                  <h4>Older</h4>
+                  <span data-prev style={{ width: '1rem', marginLeft: '-1rem' }}>
+                    ←
+                  </span>
+                  <span>{prev.frontmatter.title}</span>
+                </LinkU>
+              )}
+            </div>
+            <div data-next>
+              {next && (
+                <LinkU to={`/blog${next.fields.slug}`}>
+                  <h4>Newer</h4>
+                  <span>{next.frontmatter.title}</span>
+                  <span style={{ width: '1rem', marginRight: '-1rem' }}>→</span>
+                </LinkU>
+              )}
+            </div>
+          </Adjacent>
         </UnderPost>
       </Container>
     </Layout>

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -87,7 +87,7 @@ const Container = styled.div`
   }
 `;
 
-const BlogPostTemplate = ({ data, pageContext }) => {
+const BlogPostTemplate = ({ data, pageContext, location }) => {
   const { markdownRemark: post } = data;
   const { prev, next } = pageContext;
   return (
@@ -123,6 +123,7 @@ const BlogPostTemplate = ({ data, pageContext }) => {
         </article>
         <UnderPost>
           <applause-button
+            key={location}
             color="rgba(21,87,153,1)"
             style={{ width: '58px', height: '58px', zIndex: '9999', marginBottom: rhythm(1) }}
           />


### PR DESCRIPTION
Investigate how https://medium.com/@ColinEberhardt/free-claps-for-everyone-a-medium-style-applause-button-a6f3082a5c0e works

Thank you @ColinEberhardt!

notes:
sometimes it's invisible
![image](https://user-images.githubusercontent.com/30179461/45180940-436fdb80-b21d-11e8-8e1c-a801af181df3.png)
Can't get it to display again now.

In Firefox: repeated loading:
![2018-09-06_21-49-03](https://user-images.githubusercontent.com/30179461/45181425-b9287700-b21e-11e8-8115-b7fd81a9e451.gif)

When it is visible, claps are the same across all blog-posts even if I didn't visit them yet.

Possible solution: build own frontend and use the API the button uses
https://reactjs.org/docs/faq-ajax.html