### PR TITLE
feat: transition styling for anchor elements

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -55,13 +55,7 @@ const Header = ({ passedSx }) => {
           <Link
             to="/"
             sx={{
-              variant: "styles.a",
-              border: "none",
-              "&.is-active": {
-                borderBottomWidth: `2px`,
-                borderBottomStyle: `solid`,
-                borderBottomColor: `mutedPrimary`,
-              },
+              variant: "styles.Header.link",
             }}
             activeClassName="is-active"
           >
@@ -72,13 +66,7 @@ const Header = ({ passedSx }) => {
           <Link
             to="/uses"
             sx={{
-              variant: "styles.a",
-              border: "none",
-              "&.is-active": {
-                borderBottomWidth: `2px`,
-                borderBottomStyle: `solid`,
-                borderBottomColor: `mutedPrimary`,
-              },
+              variant: "styles.Header.link",
             }}
             activeClassName="is-active"
           >
@@ -89,13 +77,7 @@ const Header = ({ passedSx }) => {
           <Link
             to="/blog"
             sx={{
-              variant: "styles.a",
-              border: "none",
-              "&.is-active": {
-                borderBottomWidth: `2px`,
-                borderBottomStyle: `solid`,
-                borderBottomColor: `mutedPrimary`,
-              },
+              variant: "styles.Header.link",
             }}
             activeClassName="is-active"
           >

--- a/src/gatsby-plugin-theme-ui/index.js
+++ b/src/gatsby-plugin-theme-ui/index.js
@@ -38,10 +38,38 @@ const theme = merge(themeConfig, {
   },
   styles: {
     Header: {
-      backgroundColor: `mutedBackground`,
-      color: `text`,
-      borderBottom: `3px solid`,
-      borderColor: `mutedPrimary`,
+      link: {
+        "--underlineWidth": (t) => t.borderWidths[2],
+        color: `mutedText`,
+        textDecoration: `none`,
+        backgroundImage: (t) =>
+          `linear-gradient(${t.colors.mutedPrimary}, ${t.colors.mutedPrimary})`,
+        backgroundRepeat: "no-repeat",
+        backgroundSize: `0 var(--underlineWidth)`,
+        backgroundPosition: `0 100%`,
+        transition:
+          "background-size cubic-bezier(.39,.575,.565,1) 0.3s, color cubic-bezier(.39,.575,.565,1) 0.3s",
+        border: "none",
+        ":hover": {
+          color: "mutedPrimary",
+          textDecoration: `none`,
+          border: "none",
+          backgroundSize: `100% var(--underlineWidth)`,
+        },
+        "&.is-active": {
+          color: `mutedText`,
+          backgroundImage: (t) =>
+            `linear-gradient(${t.colors.mutedPrimary}, ${t.colors.mutedPrimary})`,
+          backgroundRepeat: "no-repeat",
+          backgroundSize: `100% var(--underlineWidth)`,
+          backgroundPosition: `0 100%`,
+          transition: "color cubic-bezier(.39,.575,.565,1) 0.3s",
+          border: "none",
+          ":hover": {
+            color: "mutedPrimary",
+          },
+        },
+      },
     },
     PostExtra: {
       details: {
@@ -52,24 +80,34 @@ const theme = merge(themeConfig, {
       },
       link: {
         "--underlineWidth": "1px",
+        "--blockLength": (t) => t.sizes[4],
       },
     },
     TableOfContentsList: {
-      "--underlineWidth": (t) => t.borderWidths[2],
-      "--blockLength": (t) => t.sizes[2],
       link: {
+        "--underlineWidth": (t) => t.borderWidths[2],
+        "--blockLength": (t) => t.sizes[4],
         color: `mutedText`,
         textDecoration: `none`,
         backgroundImage: (t) =>
-          `linear-gradient(90deg, ${t.colors.background}, ${t.colors.background}), linear-gradient(${t.colors.danger}, ${t.colors.danger}), linear-gradient(${t.colors.primary}, ${t.colors.primary})`,
+          `linear-gradient(90deg, ${t.colors.background}, ${t.colors.background}), linear-gradient(${t.colors.mutedPrimary}, ${t.colors.mutedPrimary}), linear-gradient(${t.colors.primary}, ${t.colors.primary})`,
         backgroundRepeat: "no-repeat",
         backgroundSize: `var(--blockLength) var(--underlineWidth), 0 var(--underlineWidth), 0 var(--underlineWidth)`,
-        backgroundPosition: `calc(var(--blockLength) * -1) 100%, 0 100%, 0 100%`,
+        backgroundPosition: `calc(var(--blockLength) * -1) 100%, 100% 100%, 0 100%`,
         transition:
-          "background-size cubic-bezier(0.39, 0.575, 0.565, 1) 2s, background-position cubic-bezier(0.39, 0.575, 0.565, 1) 2s, color cubic-bezier(0.39, 0.575, 0.565, 1) 0.5s",
-        border: "none",
+          "background-size cubic-bezier(.39,.575,.565,1) 0.3s, background-position cubic-bezier(.39,.575,.565,1) 0.3s, color cubic-bezier(.39,.575,.565,1) 0.3s",
         ":hover": {
-          color: `mutedText`,
+          color: "mutedPrimary",
+          backgroundImage: (t) =>
+            `linear-gradient(90deg, ${t.colors.background}, ${t.colors.background}), linear-gradient(${t.colors.mutedPrimary}, ${t.colors.mutedPrimary}), linear-gradient(${t.colors.primary}, ${t.colors.primary})`,
+          backgroundSize: `var(--blockLength) var(--underlineWidth), 0 var(--underlineWidth), 100% var(--underlineWidth)`,
+          backgroundPosition:
+            "calc(100% + var(--blockLength)) 100%, 100% 100%, 0 100%",
+        },
+        active: {
+          "--underlineWidth": (t) => t.borderWidths[2],
+          "--blockLength": (t) => t.sizes[6],
+          color: `mutedPrimary`,
           textDecoration: `none`,
           backgroundImage: (t) =>
             `linear-gradient(90deg, ${t.colors.background}, ${t.colors.background}), linear-gradient(${t.colors.mutedPrimary}, ${t.colors.mutedPrimary}), linear-gradient(${t.colors.primary}, ${t.colors.primary})`,
@@ -77,21 +115,13 @@ const theme = merge(themeConfig, {
           backgroundSize: `var(--blockLength) var(--underlineWidth), 100% var(--underlineWidth), 0 var(--underlineWidth)`,
           backgroundPosition: `calc(var(--blockLength) * -1) 100%, 100% 100%, 0 100%`,
           transition:
-            "background-size cubic-bezier(0.39, 0.575, 0.565, 1) 2s, background-position cubic-bezier(0.39, 0.575, 0.565, 1) 2s, color cubic-bezier(0.39, 0.575, 0.565, 1) 0.5s",
-          border: "none",
-        },
-        active: {
-          backgroundImage: (t) =>
-            `linear-gradient(90deg, ${t.colors.background}, ${t.colors.background}), linear-gradient(red,red), linear-gradient(${t.colors.primary}, ${t.colors.primary})`,
-          backgroundRepeat: "no-repeat",
-          backgroundSize: `var(--blockLength) var(--underlineWidth), 100% var(--underlineWidth), 100% var(--underlineWidth)`,
-          backgroundPosition: `calc(var(--blockLength) * -1) 100%, 0 100%, 0 100%`,
-          transition:
-            "background-size cubic-bezier(0.39, 0.575, 0.565, 1) 2s, background-position cubic-bezier(0.39, 0.575, 0.565, 1) 2s, color cubic-bezier(0.39, 0.575, 0.565, 1) 0.5s",
+            "background-size cubic-bezier(.39,.575,.565,1) 0.3s, background-position cubic-bezier(.39,.575,.565,1) 0.3s, color cubic-bezier(.39,.575,.565,1) 0.3s",
           border: "none",
           ":hover": {
+            color: "mutedPrimary",
             backgroundSize: `var(--blockLength) var(--underlineWidth), 0 var(--underlineWidth), 100% var(--underlineWidth)`,
-            backgroundPosition: `calc(100% + var(--blockLength)) 100%, 100% 100%, 0 100%`,
+            backgroundPosition:
+              "calc(100% + var(--blockLength)) 100%, 100% 100%, 0 100%",
           },
         },
       },
@@ -118,17 +148,6 @@ const theme = merge(themeConfig, {
         color: nightOwl.color,
       },
     },
-    HeaderLink: {
-      textDecoration: "none",
-      color: "text",
-      ":hover": {
-        textDecoration: `none`,
-        color: `mutedPrimary`,
-        borderBottomWidth: `2px`,
-        borderBottomStyle: `solid`,
-        borderBottomColor: `primary`,
-      },
-    },
     h1: {
       mt: 4,
       mb: 2,
@@ -153,7 +172,7 @@ const theme = merge(themeConfig, {
     },
     a: {
       "--underlineWidth": (t) => t.borderWidths[2],
-      "--blockLength": (t) => t.sizes[2],
+      "--blockLength": (t) => t.sizes[3],
       color: `mutedText`,
       textDecoration: `none`,
       backgroundImage: (t) =>
@@ -162,11 +181,10 @@ const theme = merge(themeConfig, {
       backgroundSize: `var(--blockLength) var(--underlineWidth), 100% var(--underlineWidth), 0 var(--underlineWidth)`,
       backgroundPosition: `calc(var(--blockLength) * -1) 100%, 100% 100%, 0 100%`,
       transition:
-        "background-size cubic-bezier(0.39, 0.575, 0.565, 1) 2s, background-position cubic-bezier(0.39, 0.575, 0.565, 1) 2s, color cubic-bezier(0.39, 0.575, 0.565, 1) 0.5s",
+        "background-size cubic-bezier(0.39, 0.575, 0.565, 1) 0.3s, background-position cubic-bezier(0.39, 0.575, 0.565, 1) 0.3s, color cubic-bezier(0.39, 0.575, 0.565, 1) 0.3s",
       border: "none",
       ":hover": {
         color: "mutedPrimary",
-        textDecoration: `none`,
         border: "none",
         backgroundSize: `var(--blockLength) var(--underlineWidth), 0 var(--underlineWidth), 100% var(--underlineWidth)`,
         backgroundPosition:
@@ -175,6 +193,5 @@ const theme = merge(themeConfig, {
     },
   },
 });
-console.log(theme);
 
 export default theme;

--- a/src/gatsby-plugin-theme-ui/index.js
+++ b/src/gatsby-plugin-theme-ui/index.js
@@ -50,6 +50,51 @@ const theme = merge(themeConfig, {
       title: {
         color: "mutedTextBg",
       },
+      link: {
+        "--underlineWidth": "1px",
+      },
+    },
+    TableOfContentsList: {
+      "--underlineWidth": (t) => t.borderWidths[2],
+      "--blockLength": (t) => t.sizes[2],
+      link: {
+        color: `mutedText`,
+        textDecoration: `none`,
+        backgroundImage: (t) =>
+          `linear-gradient(90deg, ${t.colors.background}, ${t.colors.background}), linear-gradient(${t.colors.danger}, ${t.colors.danger}), linear-gradient(${t.colors.primary}, ${t.colors.primary})`,
+        backgroundRepeat: "no-repeat",
+        backgroundSize: `var(--blockLength) var(--underlineWidth), 0 var(--underlineWidth), 0 var(--underlineWidth)`,
+        backgroundPosition: `calc(var(--blockLength) * -1) 100%, 0 100%, 0 100%`,
+        transition:
+          "background-size cubic-bezier(0.39, 0.575, 0.565, 1) 2s, background-position cubic-bezier(0.39, 0.575, 0.565, 1) 2s, color cubic-bezier(0.39, 0.575, 0.565, 1) 0.5s",
+        border: "none",
+        ":hover": {
+          color: `mutedText`,
+          textDecoration: `none`,
+          backgroundImage: (t) =>
+            `linear-gradient(90deg, ${t.colors.background}, ${t.colors.background}), linear-gradient(${t.colors.mutedPrimary}, ${t.colors.mutedPrimary}), linear-gradient(${t.colors.primary}, ${t.colors.primary})`,
+          backgroundRepeat: "no-repeat",
+          backgroundSize: `var(--blockLength) var(--underlineWidth), 100% var(--underlineWidth), 0 var(--underlineWidth)`,
+          backgroundPosition: `calc(var(--blockLength) * -1) 100%, 100% 100%, 0 100%`,
+          transition:
+            "background-size cubic-bezier(0.39, 0.575, 0.565, 1) 2s, background-position cubic-bezier(0.39, 0.575, 0.565, 1) 2s, color cubic-bezier(0.39, 0.575, 0.565, 1) 0.5s",
+          border: "none",
+        },
+        active: {
+          backgroundImage: (t) =>
+            `linear-gradient(90deg, ${t.colors.background}, ${t.colors.background}), linear-gradient(red,red), linear-gradient(${t.colors.primary}, ${t.colors.primary})`,
+          backgroundRepeat: "no-repeat",
+          backgroundSize: `var(--blockLength) var(--underlineWidth), 100% var(--underlineWidth), 100% var(--underlineWidth)`,
+          backgroundPosition: `calc(var(--blockLength) * -1) 100%, 0 100%, 0 100%`,
+          transition:
+            "background-size cubic-bezier(0.39, 0.575, 0.565, 1) 2s, background-position cubic-bezier(0.39, 0.575, 0.565, 1) 2s, color cubic-bezier(0.39, 0.575, 0.565, 1) 0.5s",
+          border: "none",
+          ":hover": {
+            backgroundSize: `var(--blockLength) var(--underlineWidth), 0 var(--underlineWidth), 100% var(--underlineWidth)`,
+            backgroundPosition: `calc(100% + var(--blockLength)) 100%, 100% 100%, 0 100%`,
+          },
+        },
+      },
     },
     MetaListItem: {
       title: {
@@ -106,7 +151,30 @@ const theme = merge(themeConfig, {
     inlineCode: {
       fontSize: "0.85em",
     },
+    a: {
+      "--underlineWidth": (t) => t.borderWidths[2],
+      "--blockLength": (t) => t.sizes[2],
+      color: `mutedText`,
+      textDecoration: `none`,
+      backgroundImage: (t) =>
+        `linear-gradient(90deg, ${t.colors.background}, ${t.colors.background}), linear-gradient(${t.colors.mutedPrimary}, ${t.colors.mutedPrimary}), linear-gradient(${t.colors.primary}, ${t.colors.primary})`,
+      backgroundRepeat: "no-repeat",
+      backgroundSize: `var(--blockLength) var(--underlineWidth), 100% var(--underlineWidth), 0 var(--underlineWidth)`,
+      backgroundPosition: `calc(var(--blockLength) * -1) 100%, 100% 100%, 0 100%`,
+      transition:
+        "background-size cubic-bezier(0.39, 0.575, 0.565, 1) 2s, background-position cubic-bezier(0.39, 0.575, 0.565, 1) 2s, color cubic-bezier(0.39, 0.575, 0.565, 1) 0.5s",
+      border: "none",
+      ":hover": {
+        color: "mutedPrimary",
+        textDecoration: `none`,
+        border: "none",
+        backgroundSize: `var(--blockLength) var(--underlineWidth), 0 var(--underlineWidth), 100% var(--underlineWidth)`,
+        backgroundPosition:
+          "calc(100% + var(--blockLength)) 100%, 100% 100%, 0 100%",
+      },
+    },
   },
 });
+console.log(theme);
 
 export default theme;


### PR DESCRIPTION
Quite happy with this. Learned a lot about CSS transitions and animations in the process.

Started off only transitioning the `background-size`.
Then Added in a new background coloured block, transitioned with `background-position` (Thanks for the help @jh3y!)

Jh3y's codepen demonstrating the `background-position` technique that slides a block of the background color over the underline: https://codepen.io/jh3y/pen/gOPjBPM


Still not perfect: 
- Table Of Contents active header underline slides in and out from the right instead of the left. 
  - Reason: The transition for links marked active. It replaces the underline and it needs to slide to the right. Thus, the background is positioned to the right, making it slide in from the right if the underline isn't there in the first place.
- The links in the header suddenly change when clicking to new routes.
  - Reason: Route transitions are a whole new can of worms I'm not opening at this time.